### PR TITLE
chore(flake.nix): update flake hash, and improved

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This pull request includes significant changes to the `flake.nix` file to improve the build process, update dependencies, and enhance the development environment. The most important changes include the addition of a script to update the flake, refactoring the package definition, and updating the development shells.

Improvements to the build process and dependencies:

* Added an `updateScript` to automate the process of updating the flake and its dependencies.
* Refactored the package definition to use `pkgs.fetchFromGitHub` for fetching the source and updated the package version to `0.8.2`.
* Replaced the manual setting of environment variables with direct assignments in the package definition.
* Updated the list of `nativeBuildInputs` and `buildInputs` to include `autoPatchelfHook` and `libgcc`.

Enhancements to the development environment:

* Updated the `devShells.default` to include additional tools such as `rust-analyzer`, `rustfmt`, `clippy`, and the `updateScript`.