### PR TITLE
jsonc for configuration

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use crate::{config::{Align, Config}, fum::FumResult};
 #[derive(Parser)]
 #[command(name = "fum", version, about)]
 struct FumCli {
-    #[arg(short, long, value_name = "json file", default_value = "~/.config/fum/config.json")]
+    #[arg(short, long, value_name = "config file", default_value = "~/.config/fum/config.jsonc")]
     config: Option<String>,
 
     #[arg(short, long, value_name = "string[]", value_delimiter = ',')]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -3,7 +3,7 @@ use expanduser::expanduser;
 use ratatui::style::Color;
 use serde::Deserialize;
 
-use crate::{action::Action, fum::FumResult, widget::{ContainerFlex, Direction, FumWidget}};
+use crate::{action::Action, fum::FumResult, regexes::JSONC_COMMENT_RE, widget::{ContainerFlex, Direction, FumWidget}};
 
 use super::{defaults::{align, bg, border, cover_art_ascii, direction, fg, flex, height, keybinds, layout, players, use_active_player, width}, keybind::Keybind};
 
@@ -107,7 +107,11 @@ impl Config {
     pub fn load(path: &PathBuf) -> FumResult<Self> {
         match fs::read_to_string(path) {
             Ok(config_file) => {
-                let mut config: Config = serde_json::from_str(&config_file)
+                // Clean config file for comments
+                let cleaned_config_file = JSONC_COMMENT_RE.replace_all(&config_file, "")
+                    .to_string();
+
+                let mut config: Config = serde_json::from_str(&cleaned_config_file)
                     .map_err(|err| format!("Failed to parse config: {err}"))?;
 
                 // Get expanded path of cover_art_ascii

--- a/src/regexes.rs
+++ b/src/regexes.rs
@@ -2,6 +2,8 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {
+    pub static ref JSONC_COMMENT_RE: Regex = Regex::new(r#"(?m)//.*$|/\*[\s\S]*?\*/"#).unwrap();
+
     pub static ref FORWARD_RE: Regex = Regex::new(r"forward\((-?\d+)\)").unwrap();
     pub static ref BACKWARD_RE: Regex = Regex::new(r"backward\((-?\d+)\)").unwrap();
     pub static ref POSITION_RE: Regex = Regex::new(r"^position\(\d+\)$").unwrap();


### PR DESCRIPTION
#71 #69  

* the file extension can still be anything as long as its valid json/jsonc
* the default config path that fum will be looking for is `~/.config/fum/config.jsonc`
* this not really parse "real" jsonc but just clean the comments using regex.