### PR TITLE
chore(flake.nix): update to latest release

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,13 +22,13 @@
     in {
       packages.fum = pkgs.rustPlatform.buildRustPackage rec {
         pname = "fum";
-        version = "0.8.2";
+        version = "0.9.17";
 
         src = pkgs.fetchFromGitHub {
           owner = "qxb3";
           repo = pname;
           rev = "v${version}";
-          hash = "sha256-KOxT7h7HcI3AsWKTV7BjJeVCkzReMHu3Xl6oGD+JjJw=";
+          hash = "sha256-E9Z8bs5bdNcXHRJIkzcISIz8R1wnZu8sO6tXQp+5bpQ=";
         };
 
         cargoLock = {


### PR DESCRIPTION
This pull request includes a version update for the `fum` package in the `flake.nix` file. The version has been updated from `0.8.2` to `0.9.17`, and the corresponding hash has been updated to match the new version.

Changes in `flake.nix`:

* Updated `fum` package version from `0.8.2` to `0.9.17`.
* Updated the hash for the `fum` package to `sha256-E9Z8bs5bdNcXHRJIkzcISIz8R1wnZu8sO6tXQp+5bpQ=`.